### PR TITLE
SPA to point to API on Azure App service in /4-Deployment/1-deploy-storage:

### DIFF
--- a/4-Deployment/1-deploy-storage/SPA/src/App.jsx
+++ b/4-Deployment/1-deploy-storage/SPA/src/App.jsx
@@ -32,19 +32,19 @@ const ProfileContent = () => {
      */
     const RequestProfileData = () => {
         instance.acquireTokenSilent({
-            scopes: protectedResources.graphMe.scopes,
+            scopes: protectedResources.apiHello.scopes,
             account: account
         }).then((response) => {
-            callApiWithToken(response.accessToken, protectedResources.graphMe.endpoint)
+            callApiWithToken(response.accessToken, protectedResources.apiHello.endpoint)
                 .then(response => setGraphData(response));
         }).catch((error) => {
             // in case if silent token acquisition fails, fallback to an interactive method
             if (error instanceof InteractionRequiredAuthError) {
                 if (account && inProgress === "none") {
                     instance.acquireTokenPopup({
-                        scopes: protectedResources.graphMe.scopes,
+                        scopes: protectedResources.apiHello.scopes,
                     }).then((response) => {
-                        callApiWithToken(response.accessToken, protectedResources.graphMe.endpoint)
+                        callApiWithToken(response.accessToken, protectedResources.apiHello.endpoint)
                             .then(response => setGraphData(response));
                     }).catch(error => console.log(error));
                 }


### PR DESCRIPTION
- For coupling to occur, change RequestProfileData to the apiHello scope instead of graphMe in SPA/src/App.jsx
- For more clarity, change the diagram to https://my-web-api.azurewebsites.net/hello in the README.md (pending)

## Purpose
The README Overview section explains that the SPA should be coupled with the API. For that to happen the SPA needs to use the API Hello endpoint instead. Currently the SPA is just self authenticating with the graph endpoint directly without using the deployed API. 

## Does this introduce a breaking change?
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->