### PR TITLE
use either tfp/acr claim to determine b2c policy

### DIFF
--- a/3-Authorization-II/2-call-api-b2c/SPA/src/App.jsx
+++ b/3-Authorization-II/2-call-api-b2c/SPA/src/App.jsx
@@ -31,7 +31,9 @@ const Pages = () => {
                  * policies may use "acr" instead of "tfp"). To learn more about B2C tokens, visit:
                  * https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview
                  */
-                if (event.payload.idTokenClaims['tfp'] === b2cPolicies.names.editProfile) {
+                let tfp = event.payload.idTokenClaims['tfp'] ?? event.payload.idTokenClaims["acr"];
+                
+                if (tfp=== b2cPolicies.names.editProfile) {
                     // retrieve the account from initial sing-in to the app
                     const originalSignInAccount = instance
                         .getAllAccounts()
@@ -58,7 +60,7 @@ const Pages = () => {
                  * you can replace the code below with the same pattern used for handling the return from
                  * profile edit flow
                  */
-                if (event.payload.idTokenClaims['tfp'] === b2cPolicies.names.forgotPassword) {
+                if (tfp === b2cPolicies.names.forgotPassword) {
                     let signUpSignInFlowRequest = {
                         authority: b2cPolicies.authorities.signUpSignIn.authority,
                         scopes: [

--- a/3-Authorization-II/2-call-api-b2c/SPA/src/App.jsx
+++ b/3-Authorization-II/2-call-api-b2c/SPA/src/App.jsx
@@ -8,6 +8,7 @@ import { TodoList } from './pages/TodoList';
 import { Home } from './pages/Home';
 
 import { b2cPolicies, protectedResources } from './authConfig';
+import { compareIssuingPolicy } from './utils/claimUtils';
 
 import './styles/App.css';
 
@@ -31,22 +32,15 @@ const Pages = () => {
                  * policies may use "acr" instead of "tfp"). To learn more about B2C tokens, visit:
                  * https://docs.microsoft.com/en-us/azure/active-directory-b2c/tokens-overview
                  */
-                let tfpClaim = event.payload.idTokenClaims['tfp'] ? 'tfp' : 'acr';
-                
-                function formatCase(policyName, tfpClaim) {
-                    // A custom policy's "acr" claim is returned in lowercase despite being expressed in uppercase in the Azure portal
-                    return tfpClaim === 'acr' ? policyName.toLowerCase(): policyName;
-                }
-                
-                if (event.payload.idTokenClaims[tfpClaim] === formatCase(b2cPolicies.names.editProfile, tfpClaim)) {
+                if (compareIssuingPolicy(event.payload.idTokenClaims, b2cPolicies.names.editProfile)) {
                     // retrieve the account from initial sing-in to the app
                     const originalSignInAccount = instance
                         .getAllAccounts()
                         .find(
                             (account) =>
                                 account.idTokenClaims.oid === event.payload.idTokenClaims.oid &&
-                                account.idTokenClaims.sub === event.payload.idTokenClaims.sub &&
-                                (account.idTokenClaims['tfp'] === b2cPolicies.names.signUpSignIn || account.idTokenClaims['acr'] === formatCase(b2cPolicies.names.signUpSignIn,'acr'))
+                                account.idTokenClaims.sub === event.payload.idTokenClaims.sub && 
+                                compareIssuingPolicy(account.idTokenClaims, b2cPolicies.names.signUpSignIn)        
                         );
 
                     let signUpSignInFlowRequest = {
@@ -65,7 +59,7 @@ const Pages = () => {
                  * you can replace the code below with the same pattern used for handling the return from
                  * profile edit flow
                  */
-                if (event.payload.idTokenClaims[tfpClaim] === formatCase(b2cPolicies.names.forgotPassword, tfpClaim)) {
+                if (compareIssuingPolicy(event.payload.idTokenClaims, b2cPolicies.names.forgotPassword)) {
                     let signUpSignInFlowRequest = {
                         authority: b2cPolicies.authorities.signUpSignIn.authority,
                         scopes: [

--- a/3-Authorization-II/2-call-api-b2c/SPA/src/utils/claimUtils.js
+++ b/3-Authorization-II/2-call-api-b2c/SPA/src/utils/claimUtils.js
@@ -230,7 +230,7 @@ const changeDateFormat = (date) => {
  * @returns {boolean}
  */
  export function compareIssuingPolicy(idTokenClaims, policyToCompare) {
-    let tfpMatches = idTokenClaims['tfp'] === policyToCompare
+    let tfpMatches = idTokenClaims['tfp'] === policyToCompare.toLowerCase();
     let acrMatches = idTokenClaims['acr'] === policyToCompare.toLowerCase()
     return tfpMatches || acrMatches
   }

--- a/3-Authorization-II/2-call-api-b2c/SPA/src/utils/claimUtils.js
+++ b/3-Authorization-II/2-call-api-b2c/SPA/src/utils/claimUtils.js
@@ -222,3 +222,16 @@ const changeDateFormat = (date) => {
     let dateObj = new Date(date * 1000);
     return `${date} - [${dateObj.toString()}]`;
 };
+
+/**
+ * Compare the token issuing policy with a specific policy name
+ * @param {object} idTokenClaims - Object containining token claims
+ * @param {string} policyToCompare - ID/Name of the policy as expressed in the Azure portal
+ * @returns {boolean}
+ */
+ export function compareIssuingPolicy(idTokenClaims, policyToCompare) {
+    let tfpMatches = idTokenClaims['tfp'] === policyToCompare
+    let acrMatches = idTokenClaims['acr'] === policyToCompare.toLowerCase()
+    return tfpMatches || acrMatches
+  }
+  


### PR DESCRIPTION
## Purpose

`App.jsx`   checks for `tpf`  claim to know the policy that issued the token and decide the necessary action. As a result, the sample SPA doesn't  work  correctly when using a custom policy based on https://github.com/Azure-Samples/active-directory-b2c-custom-policy-starterpack. This is because the starter-pack policies return the `tfp`   claim as `acr`

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[- ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[-] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->